### PR TITLE
Update build dependency

### DIFF
--- a/dataclass_generator/pubspec.yaml
+++ b/dataclass_generator/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   dataclass: ">=0.3.0 <0.4.0"
   # dataclass: 
     # path: ../dataclass/
-  build: ">=1.2.0 <1.3.0"
+  build: ">=1.3.0 <1.4.0"
   source_gen: ">=0.9.0 <0.10.0"
   code_builder: ">=3.2.0 <3.3.0"
   dart_style: ">=1.3.0 <1.4.0"


### PR DESCRIPTION
`build_runner` fails to generate code with the following error:
```
Precompiling executable...
Failed to precompile build_runner:build_runner:
../../flutter/.pub-cache/hosted/pub.dartlang.org/build_resolvers-1.3.7/lib/src/resolver.dart:343:10: Error: Method not found: 'SummaryBuilder'.
  return SummaryBuilder(sdkSources, sdk.context)
         ^^^^^^^^^^^^^^
../../flutter/.pub-cache/hosted/pub.dartlang.org/build_resolvers-1.3.7/lib/src/resolver.dart:332:7: Error: The setter 'useSummary' isn't defined for the class 'FolderBasedDartSdk'.
 - 'FolderBasedDartSdk' is from 'package:analyzer/src/dart/sdk/sdk.dart' ('../../flutter/.pub-cache/hosted/pub.dartlang.org/analyzer-0.39.14/lib/src/dart/sdk/sdk.dart'). 
Try correcting the name to the name of an existing setter, or defining a setter or field named 'useSummary'.
    ..useSummary = false
```

According to [this](https://github.com/dart-lang/build/issues/2763#issuecomment-669544305) thread, the issue can be fixed by updating `build_resolvers` version to `1.3.10` but `build_resolvers >=1.3.8 depends on build >=1.3.0 <1.4.0`.